### PR TITLE
Add simple home assistant web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# Hello-Paris
-Juste un dépotoir public
+# Hello-Paris Home Assistant Interface
+
+Ce dépôt contient une petite application Flask pouvant servir d'interface simple pour piloter des appareils connectés à un Raspberry Pi.
+
+## Installation
+
+Installez les dépendances :
+
+```bash
+pip install -r requirements.txt
+```
+
+## Utilisation
+
+Lancez l'application :
+
+```bash
+python app.py
+```
+
+Ouvrez ensuite votre navigateur sur `http://adresse-ip-du-pi:5000` pour accéder à l'interface.
+
+Par défaut deux appareils fictifs sont déclarés (`light` et `fan`). Sur un Raspberry Pi, ils utiliseront les pins GPIO 17 et 27 via `gpiozero`. Sur une autre plateforme, des objets factices sont utilisés pour permettre des tests sans matériel.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, render_template, redirect, url_for
+try:
+    from gpiozero import LED
+    gpio_available = True
+except ImportError:
+    gpio_available = False
+
+app = Flask(__name__)
+
+# If running on Raspberry Pi, setup GPIO pins
+if gpio_available:
+    devices = {
+        "light": LED(17),
+        "fan": LED(27)
+    }
+else:
+    # Fallback: mock objects for non-Raspberry environments
+    class MockDevice:
+        def __init__(self):
+            self._state = False
+        def on(self):
+            self._state = True
+        def off(self):
+            self._state = False
+        @property
+        def value(self):
+            return self._state
+    devices = {
+        "light": MockDevice(),
+        "fan": MockDevice()
+    }
+
+@app.route('/')
+def index():
+    return render_template('index.html', devices=devices)
+
+@app.route('/toggle/<name>')
+def toggle(name):
+    device = devices.get(name)
+    if device:
+        if device.value:
+            device.off()
+        else:
+            device.on()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+gpiozero

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Home Assistant</title>
+</head>
+<body>
+    <h1>Interface Home Assistant</h1>
+    <ul>
+        {% for name, device in devices.items() %}
+        <li>
+            {{ name }} - Etat : {{ 'On' if device.value else 'Off' }}
+            <a href="{{ url_for('toggle', name=name) }}">Toggle</a>
+        </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask web app with GPIO support
- create basic HTML template to toggle devices
- document installation and usage
- list dependencies

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: cannot access pypi)*

------
https://chatgpt.com/codex/tasks/task_e_687f747a59588329ad2ff5a263746e7c